### PR TITLE
Prevent clipping of scatter points in margin

### DIFF
--- a/application.py
+++ b/application.py
@@ -70,6 +70,7 @@ def update_daily_index(nonce):  # deliberate unused arg
                 marker_color=luts.colors[1],
                 name="Above Average",
                 mode="markers",
+                cliponaxis=False,
                 hovertemplate="%{x} <br><b>Daily Index:</b> %{y}",
             ),
             go.Scatter(
@@ -78,6 +79,7 @@ def update_daily_index(nonce):  # deliberate unused arg
                 marker_color=luts.colors[0],
                 name="Below Average",
                 mode="markers",
+                cliponaxis=False,
                 hovertemplate="%{x} <br><b>Daily Index:</b> %{y}",
             ),
             go.Scatter(


### PR DESCRIPTION
Test by examining the scatter points at the left and right margins.  These should not be clipped, i.e. they should be full circles and not half-moons.