### PR TITLE
Abbreviate month in x-axis tick labels to fix exported PNG overlap bug

### DIFF
--- a/application.py
+++ b/application.py
@@ -97,6 +97,7 @@ def update_daily_index(nonce):  # deliberate unused arg
             xaxis=dict(
                 showgrid=True,
                 type="date",
+                tickformat='%b %-d, %Y',
                 range=[start_date, end_date],
                 rangeslider=dict(
                     range=[di["date"].iloc[0], di["date"].iloc[-1]], visible=True


### PR DESCRIPTION
Fixes #55.

This PR solves the problem described in #55 by abbreviating the month names in the x-axis tick label.

To replicate the problem, run the app locally with `FLASK_DEBUG` set to `False` so that the app pulls the latest data. Then, use the graph sliders to adjust the graph date range to resemble the screenshot in #55. Then use the camera button in the upper-right corner of the graph to export it to PNG. You should see the overlapping x-axis tick labels.

To test this PR, do the same thing from the `abbreviated_month` branch and verify that the x-axis tick labels are not overlapping.