### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/luts.py
+++ b/luts.py
@@ -21,7 +21,7 @@ index_string = f"""
             data-do-not-track="true" 
             data-website-id="3904e4d3-ac89-47f3-8220-4576c671acd5"
             data-domains="accap.uaf.edu"
-            src="https://umami.snap.uaf.edu/umami.js"
+            src="https://umami.snap.uaf.edu/script.js"
         ></script>        
         {{%metas%}}
         <title>{{%title%}}</title>


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `luts.py` to:

```
<script async defer
    data-do-not-track="true"
    data-website-id="3904e4d3-ac89-47f3-8220-4576c671acd5"
    src="http://localhost:9999/script.js"
></script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/3904e4d3-ac89-47f3-8220-4576c671acd5